### PR TITLE
More flexible log uploader

### DIFF
--- a/src/main/kotlin/utilbot/extensions/LogUpload.kt
+++ b/src/main/kotlin/utilbot/extensions/LogUpload.kt
@@ -38,7 +38,6 @@ class LogUpload : Extension() {
                 val logs = uploadLogFiles(attachments)
 
                 reply.edit {
-
                     if (logs.isEmpty()) {
                         content = "Failed to upload!"
                         return@edit
@@ -76,7 +75,6 @@ class LogUpload : Extension() {
                 val logs = uploadLogFiles(attachments)
 
                 reply.edit {
-
                     if (logs.isEmpty()) {
                         content = "Failed to upload!"
                         return@edit
@@ -99,9 +97,9 @@ class LogUpload : Extension() {
     }
 
     private fun isValidLog(attachment: Attachment, allowedExtensions: List<String>? = null): Boolean {
-        return attachment.size < 10_000_000
-                && attachment.contentType?.contains("text/plain") != false
-                && (allowedExtensions == null || allowedExtensions.any { attachment.filename.endsWith(it) })
+        return attachment.size < 10_000_000 &&
+                attachment.contentType?.contains("text/plain") != false &&
+                (allowedExtensions == null || allowedExtensions.any { attachment.filename.endsWith(it) })
     }
 
     private suspend fun uploadLogFiles(attachments: List<Attachment>): List<Pair<String, LogData>> {

--- a/src/main/kotlin/utilbot/extensions/LogUpload.kt
+++ b/src/main/kotlin/utilbot/extensions/LogUpload.kt
@@ -2,9 +2,14 @@ package utilbot.extensions
 
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.event
+import com.kotlindiscord.kord.extensions.extensions.publicMessageCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondEphemeral
 import com.kotlindiscord.kord.extensions.utils.download
-import com.kotlindiscord.kord.extensions.utils.respond
 import dev.kord.core.behavior.edit
+import dev.kord.core.behavior.interaction.followup.edit
+import dev.kord.core.behavior.reply
+import dev.kord.core.entity.Attachment
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.modify.actionRow
 import io.ktor.client.request.*
@@ -19,44 +24,33 @@ import utilbot.Util.client
 
 class LogUpload : Extension() {
     override val name = "log_upload"
+    private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun setup() {
         event<MessageCreateEvent> {
             action {
-                //if (event.message.channelId !in Util.CONFIG.logUploadAllowedIds) {
-                //    return@action
-                //}
+                val attachments = event.message.attachments
+                    .filter { isValidLog(it, listOf(".log", "server.txt", "client.txt")) }
 
-                for (attachment in event.message.attachments) {
-                    if (attachment.size > 10_000_000 && attachment.contentType?.contains("text/plain") == false) {
-                        return@action
+                if (attachments.isEmpty()) return@action
+
+                val reply = event.message.reply { content = "Logs detected, uploading..." }
+                val logs = uploadLogFiles(attachments)
+
+                reply.edit {
+
+                    if (logs.isEmpty()) {
+                        content = "Failed to upload!"
+                        return@edit
                     }
-                    val message = event.message.respond { content = "Uploading ${attachment.filename}" }
-                    val text = attachment.download().decodeToString()
 
-                    val response = client.post("$MCLOGS_BASE_URL/1/log") {
-                        contentType(ContentType.Application.FormUrlEncoded)
-                        setBody(
-                            FormDataContent(
-                                Parameters.build {
-                                    append("content", text)
-                                }
-                            )
-                        )
-                    }.readBytes().decodeToString()
+                    content = "Uploaded ${logs.size} logs"
 
-                    val json = Json { ignoreUnknownKeys = true }
-                    val log = json.decodeFromString<LogData>(response)
-
-                    message.edit {
-                        content = if (log.success) "${attachment.filename} uploaded" else "Failed to upload!"
-
-                        if (log.error != null) content += " ${log.error}"
-
-                        if (log.url != null) {
-                            actionRow {
-                                linkButton(log.url) {
-                                    label = "Click to view"
+                    actionRow {
+                        for (response in logs) {
+                            response.second.url?.let {
+                                linkButton(it) {
+                                    label = response.first
                                 }
                             }
                         }
@@ -64,6 +58,75 @@ class LogUpload : Extension() {
                 }
             }
         }
+
+        publicMessageCommand {
+            name = "Upload Logs"
+
+            action {
+                val attachments = event.interaction.messages.values.flatMap { message ->
+                    message.attachments.filter { isValidLog(it) }
+                }
+
+                if (attachments.isEmpty()) {
+                    respondEphemeral { content = "No valid logs found" }
+                    return@action
+                }
+
+                val reply = respond { content = "Found logs, uploading..." }
+                val logs = uploadLogFiles(attachments)
+
+                reply.edit {
+
+                    if (logs.isEmpty()) {
+                        content = "Failed to upload!"
+                        return@edit
+                    }
+
+                    content = "Uploaded ${logs.size} logs"
+
+                    actionRow {
+                        for (response in logs) {
+                            response.second.url?.let {
+                                linkButton(it) {
+                                    label = response.first
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun isValidLog(attachment: Attachment, allowedExtensions: List<String>? = null): Boolean {
+        return attachment.size < 10_000_000
+                && attachment.contentType?.contains("text/plain") != false
+                && (allowedExtensions == null || allowedExtensions.any { attachment.filename.endsWith(it) })
+    }
+
+    private suspend fun uploadLogFiles(attachments: List<Attachment>): List<Pair<String, LogData>> {
+        val responses = attachments.map {
+            it.filename to it.download().decodeToString()
+        }.map {
+            it.first to upload(it.second)
+        }
+
+        return responses.filter { it.second.success }
+    }
+
+    private suspend fun upload(log: String): LogData {
+        return json.decodeFromString(
+            client.post("$MCLOGS_BASE_URL/1/log") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody(
+                    FormDataContent(
+                        Parameters.build {
+                            append("content", log)
+                        }
+                    )
+                )
+            }.readBytes().decodeToString()
+        )
     }
 
     @Serializable


### PR DESCRIPTION
A more flexible implementation of a log uploader that:

- Will put all logs per request in one message
- Checks if the extension is correct before uploading automatically
- Gives you the option to upload logs anyway that dont get picked up automatically